### PR TITLE
Upgrade observe mode and admin tournament flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the CopperHead Client are documented in this file.
 
+## [4.1.0] - 2026-04-14
+
+### Changed
+- Version bump to 4.1.0
+
 ## [4.0.8] - 2026-04-08
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,6 @@ All notable changes to the CopperHead Client are documented in this file.
 ### Changed
 - Version bump to 4.1.0
 
-## [4.0.8] - 2026-04-08
-
-### Changed
-- Version bump to 4.0.8
-
 ## [4.0.7] - 2026-04-02
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the CopperHead Client are documented in this file.
 
+## [4.0.8] - 2026-04-08
+
+### Changed
+- Version bump to 4.0.8
+
 ## [4.0.7] - 2026-04-02
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,14 @@
 
 All notable changes to the CopperHead Client are documented in this file.
 
-## [4.1.0] - 2026-04-14
+## [v4.1.0] - 2026-04-14
 
 ### Changed
 - Version bump to 4.1.0
+- After a successful admin start request, the client can switch directly into observe mode
+
+### Fixed
+- Start flow now stops immediately when the start-tournament request returns an error
 
 ## [4.0.7] - 2026-04-02
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ In Administrator Mode, the client provides additional controls:
 
 - **Lobby management**: Admit or kick players from the lobby
 - **Add bots**: Add CopperBot opponents at a specific difficulty level (1–10) or random
-- **Start tournament**: Manually start the tournament, optionally auto-filling empty slots with lobby players and bots
+- **Start tournament**: Manually start the tournament, optionally auto-filling empty slots with lobby players and bots; on success the admin client switches straight into Observe mode
 - **Pause / Resume / Cancel**: Control a running tournament
 - **Observe mode**: The right panel shows lobby status with admin controls (Admit/Kick players, Add Bot) in addition to the lobby list visible to all observers
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CopperHead Client
 
-Version: 4.0.7
+Version: 4.0.8
 
 Web-based client for the CopperHead 2-player Snake game.
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ You can play CopperHead versus friends or a bot by visiting this client hosted o
 
 To play a game, you will need to connect to a running CopperHead server from the client. For instructions on starting a server, visit the [CopperHead Server](../copperhead-server/) repository.
 
-> ⚠️ **VPN Warning:** If you are connected via a VPN, you may experience latency/lag that affects gameplay. For the best experience, disconnect from your VPN before playing.
-
 ## Client Features
 
 - Play against another player or a bot with keyboard controls
@@ -59,6 +57,23 @@ When launching a server in Codespaces, the terminal will display a ready-to-use 
 - **Arrow keys** or **WASD**: Move snake
 - **Space**: Ready up / Restart
 - **ESC** or **`** (backtick): Return to setup
+
+### Observer Controls
+
+- **↑ / ↓**: Switch between matches in the current round
+- **ESC** or **`** (backtick): Return to Entry Screen
+
+## Administrator Mode
+
+The server owner can access Administrator Mode by including the `admin` token in the client URL (e.g. `?admin=abc123`). The admin token is displayed in the server console when the server starts.
+
+In Administrator Mode, the client provides additional controls:
+
+- **Lobby management**: Admit or kick players from the lobby
+- **Add bots**: Add CopperBot opponents at a specific difficulty level (1–10) or random
+- **Start tournament**: Manually start the tournament, optionally auto-filling empty slots with lobby players and bots
+- **Pause / Resume / Cancel**: Control a running tournament
+- **Observe mode**: The right panel shows lobby status with admin controls (Admit/Kick players, Add Bot) in addition to the lobby list visible to all observers
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CopperHead Client
 
-Version: 4.0.8
+Version: 4.1.0
 
 Web-based client for the CopperHead 2-player Snake game.
 
@@ -26,7 +26,7 @@ To play a game, you will need to connect to a running CopperHead server from the
 
 ## Quick Start 
 
-See [CopperHead Server](../copperhead-server/) repository
+See [CopperHead Server](https://github.com/revodavid/copperhead-server) repository
 
 1. Start the CopperHead server (via Codespaces or locally)
 2. Open the client in a browser (GitHub Pages or locally)

--- a/UI-instructions.md
+++ b/UI-instructions.md
@@ -1,8 +1,8 @@
 # Instructions for building Client UI
 
-## Lobby screen
+## Entry screen
 
-Also referred to as the "Entry Screen", this screen appears when first launching the client.
+This screen appears when first launching the client.
 
 *This page has two modes: Administrator and Player. In Player mode, the UI allows a human player to join a lobby and play games, or to observe games in progress. In Administrator mode, the UI additionally allows the server owner skip the lobby to join the tournament, and to manage players in the lobby, and add bots to the competition.*
 
@@ -199,23 +199,45 @@ Header: Same as play screen.
 
 Below, the observer screen is divided into three columns with the same layout and styling as the Game Screen:
 
-### Scoreboard (left, narrow)
+### Scoreboard and Round Info (left, narrow)
 
-Identical to Play Game screen, showing scores for observed game.
+This column replaces the Play Game scoreboard with a combined view showing:
+
+1. **Score table**: Identical to Play Game screen, showing scores for observed game.
+
+2. **Points to win**: "First to **N** wins" (where N is highlighted in orange).
+
+3. **Round heading**: "Round X of Y" with a separator line below.
+
+4. **Round table**: Same match table as the Entry Screen showing all matches in the current round with player names and current scores. The currently-observed match is highlighted. Scores for active matches are in orange; completed matches show the winner's score in green. The score column never wraps (always displays on one line, e.g. "2 - 1").
+
+5. **Controls**:
+   - ↑ ↓ Next / Previous Match (clickable)
+   - Esc or \` Return to Entry Screen (clickable)
 
 ### Gamefield grid (center, wide)
 
-Identical to Play Game screen, showing gamefield for the observed game. (The user can switch between games in the round. If the game has ended, show the final state and score.)
+Identical to Play Game screen, showing gamefield for the observed game. If the game has ended, show the final state and score.
 
-### Instructions panel (right, narrow)
+### Right panel
 
-Controls: Same styling as Play Game screen, but with keybindings for observer mode:
- - Up: Previous match
- - Down: Next match
- - ESC: Return to Lobby 
+For administrators: Show the Lobby panel (same as Entry Screen) with player list, Admit/Kick buttons, and Add Bot controls.
 
-Current round matches: Include the same table from the Entry Screen in the current round of the competition, with player names and current scores. (Do not include the round number, which is already shown in the left pane.)
+For non-administrators: Show the Instructions panel (same as Play Game screen) with observer keybindings.
 
-Make this column wide enough to show the full match table without horizontal scrolling or wrapping.
+### Observer Behavior: Follow States
 
+The observer has two follow states:
+
+**FOLLOWING_ENABLED** (default): Active whenever watching a live game.
+- The center pane always shows an active game.
+- When the observed match completes, the observer automatically switches to another active match in the round (if any remain).
+- When a new round begins, the observer follows the winning player from the last-observed match to their new game.
+
+**FOLLOWING_DISABLED**: Activated when the observer manually navigates (↑/↓) to a completed match.
+- The status bar shows "Match complete: [winner] wins!".
+- The observer stays on that completed game until one of the following occurs:
+  - The observer navigates to an active game → returns to FOLLOWING_ENABLED
+  - The next round begins → follows the winning player to their new game → returns to FOLLOWING_ENABLED
+  - A new tournament begins → selects a random active game → returns to FOLLOWING_ENABLED
 

--- a/UI-instructions.md
+++ b/UI-instructions.md
@@ -53,10 +53,11 @@ Show round table with all matches in Round 1. All scores are listed as 0-0 in re
 
 *These buttons are only shown if the user is the server administrator*
 
-* "Start Competition"
+* "Start Tournament"
   - If all slots are filled, this button is colored green and enabled. Clicking it starts the competition immediately.
   - If some slots are open but enough players are in the lobby to fill them, this button is colored orange and enabled. Clicking it fills open slots with players from the lobby and starts the competition.
   - If some slots are open and not enough players are in the lobby to fill them, this button is colored blue and enabled. Clicking it fills open slots with players from the lobby and bots of random difficulty, and starts the competition.
+  - If the start request succeeds, the admin client can switch directly into Observe mode without any extra manual step.
 
 Below the button, add this INFORMATIONAL NOTE according to context and the state of the `auto_start` server option (`"always"`, `"admit_only"`, or `"never"`):
 

--- a/game.js
+++ b/game.js
@@ -1969,10 +1969,13 @@ function updateLobbyPanel() {
         
         const nameSpan = document.createElement('span');
         nameSpan.textContent = player.name || 'Unknown';
-        nameSpan.className = player.in_slot ? 'lobby-player-assigned' : 'lobby-player-waiting';
+        nameSpan.className = 'player-name ' + (player.in_slot ? 'lobby-player-assigned' : 'lobby-player-waiting');
         item.appendChild(nameSpan);
         
         if (isAdmin()) {
+            const btnGroup = document.createElement('div');
+            btnGroup.className = 'lobby-btn-group';
+            
             const addBtn = document.createElement('button');
             addBtn.textContent = 'Admit';
             addBtn.className = 'btn-add-to-slot';
@@ -1984,8 +1987,9 @@ function updateLobbyPanel() {
             kickBtn.className = 'btn-kick';
             kickBtn.onclick = () => lobbyKick(player.uid);
             
-            item.appendChild(addBtn);
-            item.appendChild(kickBtn);
+            btnGroup.appendChild(addBtn);
+            btnGroup.appendChild(kickBtn);
+            item.appendChild(btnGroup);
         }
         
         list.appendChild(item);

--- a/game.js
+++ b/game.js
@@ -2145,7 +2145,7 @@ async function lobbyAddToSlot(uid) {
     }
 }
 
-async function startTournament() {
+async function startTournament(switchToObserve = false) {
     if (!isAdmin() || !adminToken) return;
     
     const baseUrl = getServerUrl();
@@ -2160,8 +2160,12 @@ async function startTournament() {
         if (!response.ok) {
             const err = await response.json().catch(() => null);
             alert('Failed to start tournament: ' + (err?.detail || response.statusText));
+            return;
         }
-        // Server will handle starting the tournament
+
+        if (switchToObserve) {
+            observe();
+        }
     } catch (e) {
         alert('Error starting tournament: ' + e.message);
     }
@@ -2175,7 +2179,7 @@ async function handleCompetitionButton() {
     if (compState === "in_progress") {
         await pauseTournament();
     } else {
-        await startTournament();
+        await startTournament(true);
     }
 }
 

--- a/game.js
+++ b/game.js
@@ -27,6 +27,8 @@ let totalRounds = 0;
 let pointsToWin = 5;
 let observerFollowingPlayer = null; // Track winner name to follow between rounds
 let observerMatchComplete = false; // Track if we're waiting for next round
+let observerPollInterval = null; // Polling interval for observer lobby/competition data
+let observerPollGeneration = 0; // Generation counter to discard stale poll responses
 let botsBeingAdded = false; // Track if bots are in the process of being added
 let lastOpenSlots = null; // Track open slots to detect bot connections
 let countdownRemaining = 0;  // Tournament countdown seconds from server
@@ -66,6 +68,8 @@ const gameStatusDiv = document.getElementById("game-status");
 const roundInfoDiv = document.getElementById("round-info");
 const pointsToWinInfoDiv = document.getElementById("points-to-win-info");
 const originalInstructionsHtml = instructionsDiv ? instructionsDiv.innerHTML : "";
+const observerLeftContent = document.getElementById("observer-left-content");
+const observerRightPanel = document.getElementById("observer-right-panel");
 const serverUrlDisplay = document.getElementById("server-url-display");
 const serverVersion = document.getElementById("server-version");
 
@@ -857,6 +861,7 @@ function observe() {
     
     const wsUrl = baseUrl.replace(/\/ws\/?$/, "") + "/ws/observe";
     connectWebSocket(wsUrl);
+    startObserverPolling();
     if (wasInLobby) {
         inLobby = false;
         updateLobbyButton();
@@ -882,6 +887,7 @@ function observeRoom(roomId) {
     
     const wsUrl = baseUrl.replace(/\/ws\/?$/, "") + "/ws/observe?room=" + encodeURIComponent(roomId);
     connectWebSocket(wsUrl);
+    startObserverPolling();
     if (wasInLobby) {
         inLobby = false;
         updateLobbyButton();
@@ -1189,16 +1195,10 @@ function handleMessage(data) {
                     setStatus(`Game over. ${winnerName} wins the game. Waiting for next game to start`, "victory");
                 }
                 
-                // Request updated room list periodically
-                const roomUpdateInterval = setInterval(() => {
-                    if (ws && ws.readyState === WebSocket.OPEN) {
-                        ws.send(JSON.stringify({ action: "get_rooms" }));
-                    } else {
-                        clearInterval(roomUpdateInterval);
-                    }
-                }, 1000);
-                // Clear interval after 10 seconds
-                setTimeout(() => clearInterval(roomUpdateInterval), 10000);
+                // Request updated room list so observer info stays current
+                if (ws && ws.readyState === WebSocket.OPEN) {
+                    ws.send(JSON.stringify({ action: "get_rooms" }));
+                }
             } else {
                 const opponentId = playerId === 1 ? 2 : 1;
                 const opponentName = names[opponentId] || "Opponent";
@@ -1319,19 +1319,32 @@ function handleMessage(data) {
             if (isObserver) {
                 // Check if this is the final round
                 if (currentRound >= totalRounds) {
-                    // Final round - show result then return to entry screen
+                    // Final round — show champion, stay in observe mode
                     setStatus(`🏆 Tournament complete. Champion: ${matchWinnerName}!`, "victory");
-                    setTimeout(() => {
-                        returnToEntryScreen();
-                    }, 3000);
+                    // Don't return to entry screen — stay and wait for next tournament
                 } else {
                     // Not final round - track winner to follow to next round
                     observerFollowingPlayer = matchWinnerName;
                     observerMatchComplete = true;
                     
-                    // Show victory status for match complete
-                    let matchMsg = `Match complete: ${matchWinnerName} advances! Waiting for other Round ${currentRound} matches to complete`;
-                    setStatus(matchMsg, "victory");
+                    // Check if there's another active match to watch right now
+                    const otherMatch = activeRooms.find(r =>
+                        r.room_id !== roomId && !isMatchComplete(r)
+                    );
+                    if (otherMatch) {
+                        // Switch to another in-progress match while we wait
+                        roomId = otherMatch.room_id;
+                        currentRoomIndex = activeRooms.findIndex(r => r.room_id === roomId);
+                        if (ws && ws.readyState === WebSocket.OPEN) {
+                            ws.send(JSON.stringify({ action: "switch_room", room_id: roomId }));
+                        }
+                        const p1 = otherMatch.names?.[1] || "Player 1";
+                        const p2 = otherMatch.names?.[2] || "Player 2";
+                        setStatus(`Watching: ${p1} vs ${p2}. ${matchWinnerName} advances!`, "playing");
+                    } else {
+                        // All matches done — waiting for next round
+                        setStatus(`Match complete: ${matchWinnerName} advances! Waiting for next round`, "victory");
+                    }
                 }
             } else {
                 // Check if current player won or lost
@@ -1370,9 +1383,11 @@ function handleMessage(data) {
                 reset_in: resetIn,
                 champion_matches: championMatches
             };
-            // Only return to entry screen if observing or actively playing.
+            // Return to entry screen for players; observers stay to watch next tournament.
             // Lobby players stay connected so they can be matched in the next tournament.
-            if (isObserver || roomId) {
+            if (isObserver) {
+                setStatus(`🏆 Tournament complete. Champion: ${champion}! Next tournament starting soon...`, "victory");
+            } else if (roomId) {
                 returnToEntryScreen();
             }
             updateCompetitionDisplay(window.lastCompetitionData);
@@ -1479,6 +1494,8 @@ function sendReady() {
 
 function returnToEntryScreen() {
     stopLocalCountdown();
+    stopObserverPolling();
+    hideObserverPanels();
     if (ws) {
         ws.close();
         ws = null;
@@ -1742,6 +1759,12 @@ function updateMatchInfo() {
         pointsToWin = serverSettings.pointsToWin;
     }
     
+    // Observer uses its own left-pane layout for match info
+    if (isObserver) {
+        matchInfoDiv.classList.add("hidden");
+        return;
+    }
+    
     if (currentRound > 0 || pointsToWin > 0) {
         matchInfoDiv.classList.remove("hidden");
         
@@ -1776,14 +1799,21 @@ function updateMatchInfo() {
 function updateObserverInfo() {
     if (!isObserver) return;
     
-    // Update the instructions panel to show observer info
-    const instructionsDiv = document.getElementById("instructions");
-    if (!instructionsDiv) return;
+    // Hide the player match-info panel (observer uses its own layout)
+    if (matchInfoDiv) matchInfoDiv.classList.add("hidden");
     
-    // Build matches table with live scores
-    const pointsToWin = serverSettings.pointsToWin || 5;
+    // Hide player instructions, show observer panels
+    if (instructionsDiv) instructionsDiv.classList.add("hidden");
+    if (observerRightPanel) observerRightPanel.classList.remove("hidden");
+    
+    // --- LEFT PANE: points-to-win, round matches table, controls ---
+    if (!observerLeftContent) return;
+    observerLeftContent.classList.remove("hidden");
+    
+    const ptw = serverSettings.pointsToWin || 5;
     const byePlayer = window.lastCompetitionData?.bye_player;
     
+    // Build matches table with live scores
     let matchRows = [];
     if (activeRooms.length > 0) {
         matchRows = activeRooms.map(r => {
@@ -1793,10 +1823,8 @@ function updateObserverInfo() {
             const s1 = r.wins?.[1] || 0;
             const s2 = r.wins?.[2] || 0;
             
-            // Check if match is complete
-            const p1Won = s1 >= pointsToWin;
-            const p2Won = s2 >= pointsToWin;
-            
+            const p1Won = s1 >= ptw;
+            const p2Won = s2 >= ptw;
             const s1Style = p1Won ? 'style="color: #2ecc71; font-weight: bold;"' : '';
             const s2Style = p2Won ? 'style="color: #2ecc71; font-weight: bold;"' : '';
             
@@ -1808,7 +1836,6 @@ function updateObserverInfo() {
         });
     }
     
-    // Add Bye row if there's a bye player this round
     if (byePlayer) {
         matchRows.push(`<tr class="bye-row">
             <td colspan="3" style="text-align: center; color: #f39c12;">🎫 Bye: ${byePlayer}</td>
@@ -1824,20 +1851,18 @@ function updateObserverInfo() {
                 </tbody>
             </table>`;
     } else {
-        matchesTableHtml = "<div>No active matches</div>";
+        matchesTableHtml = `<div style="color: #666; text-align: center; font-size: 0.85em;">No active matches</div>`;
     }
     
-    instructionsDiv.innerHTML = `
-        <h3>👁️ Observer Mode</h3>
-        <div class="instruction-section">
-            <h4>Controls</h4>
-            <div class="key-row clickable-control" onclick="observerPrevMatch()"><span class="key">↑</span> Previous match</div>
-            <div class="key-row clickable-control" onclick="observerNextMatch()"><span class="key">↓</span> Next match</div>
+    const roundLabel = currentRound > 0 ? `Round ${currentRound} of ${totalRounds}` : "Matches";
+    
+    observerLeftContent.innerHTML = `
+        <div class="observer-points-to-win">First to <span>${ptw}</span> wins</div>
+        <h4 class="observer-round-heading">${roundLabel}</h4>
+        ${matchesTableHtml}
+        <div class="observer-controls">
+            <div class="key-row"><span class="key clickable-control" onclick="observerPrevMatch()">↑</span> <span class="key clickable-control" onclick="observerNextMatch()">↓</span> Next / Previous Match</div>
             <div class="key-row clickable-control" onclick="returnToEntryScreen()"><span class="key">Esc</span> or <span class="key">\`</span> Return to lobby</div>
-        </div>
-        <div class="instruction-section">
-            <h4>Current Round Matches</h4>
-            ${matchesTableHtml}
         </div>
     `;
 }
@@ -1865,6 +1890,7 @@ function observerNextMatch() {
 }
 
 function restorePlayerInstructions() {
+    hideObserverPanels();
     if (instructionsDiv && originalInstructionsHtml) {
         instructionsDiv.innerHTML = originalInstructionsHtml;
     }
@@ -2232,4 +2258,252 @@ function showCopyToast(message) {
     setTimeout(() => {
         copyToast.classList.remove('show');
     }, 2000);
+}
+
+// --- Observer mode helper functions ---
+
+function isMatchComplete(room) {
+    // A match is complete when either player has reached pointsToWin
+    const ptw = serverSettings.pointsToWin || 5;
+    const s1 = room.wins?.[1] || 0;
+    const s2 = room.wins?.[2] || 0;
+    return s1 >= ptw || s2 >= ptw;
+}
+
+function hideObserverPanels() {
+    // Hide observer-specific panels and restore player panels
+    if (observerLeftContent) {
+        observerLeftContent.classList.add("hidden");
+        observerLeftContent.innerHTML = "";
+    }
+    if (observerRightPanel) {
+        observerRightPanel.classList.add("hidden");
+        observerRightPanel.innerHTML = "";
+    }
+    if (instructionsDiv) {
+        instructionsDiv.classList.remove("hidden");
+    }
+    if (matchInfoDiv) {
+        matchInfoDiv.classList.remove("hidden");
+    }
+}
+
+// --- Observer right pane: lobby table + admin controls ---
+
+function updateObserverLobbyPanel() {
+    if (!isObserver || !observerRightPanel) return;
+    
+    const compState = window.lastCompetitionData?.state || "waiting_for_players";
+    const autoStart = window.lastLobbyData?.auto_start || "";
+    
+    // Build lobby status message
+    let statusMsg = "";
+    if (autoStart === "always" || autoStart === "admit_only") {
+        statusMsg = "New players auto-admitted";
+    } else if (autoStart === "never") {
+        if (lobbyPlayers.length === 0) {
+            statusMsg = "Waiting for players to join";
+        } else if (isAdmin()) {
+            statusMsg = "Click 'Admit' to add players";
+        } else {
+            statusMsg = "Waiting for admin to start";
+        }
+    }
+    
+    // Build player list HTML
+    let playersHtml = "";
+    if (lobbyPlayers.length === 0) {
+        playersHtml = `<div class="obs-no-players">No players in lobby</div>`;
+    } else {
+        const playerItems = lobbyPlayers.map(player => {
+            const nameClass = player.in_slot ? 'obs-lobby-assigned' : 'obs-lobby-waiting';
+            let buttonsHtml = "";
+            if (isAdmin()) {
+                const admitDisabled = player.in_slot || compState !== "waiting_for_players" ? "disabled" : "";
+                buttonsHtml = `
+                    <div class="obs-btn-group">
+                        <button class="obs-btn-admit" ${admitDisabled} onclick="obsAdmitPlayer('${player.uid}')">Admit</button>
+                        <button class="obs-btn-kick" onclick="obsKickPlayer('${player.uid}')">Kick</button>
+                    </div>`;
+            }
+            return `<div class="obs-lobby-player">
+                <span class="player-name ${nameClass}">${player.name || 'Unknown'}</span>
+                ${buttonsHtml}
+            </div>`;
+        });
+        playersHtml = `<div class="obs-lobby-list">${playerItems.join("")}</div>`;
+    }
+    
+    // Build admin tournament controls
+    let adminControlsHtml = "";
+    if (isAdmin()) {
+        if (compState === "waiting_for_players") {
+            const hasPlayers = lobbyPlayers.some(p => p.in_slot) || lobbyPlayers.length > 0;
+            adminControlsHtml = `
+                <div class="obs-admin-controls">
+                    <button class="obs-btn-start" onclick="obsStartTournament()" ${hasPlayers ? '' : 'disabled'}>Start Tournament</button>
+                </div>`;
+        } else if (compState === "in_progress") {
+            adminControlsHtml = `
+                <div class="obs-admin-controls">
+                    <button class="obs-btn-pause" onclick="obsPauseTournament()">Pause Tournament</button>
+                </div>`;
+        } else if (compState === "paused") {
+            adminControlsHtml = `
+                <div class="obs-admin-controls">
+                    <div class="obs-pause-controls">
+                        <button class="obs-btn-resume" onclick="obsResumeTournament()">Resume</button>
+                        <button class="obs-btn-cancel" onclick="obsCancelTournament()">Cancel</button>
+                    </div>
+                </div>`;
+        }
+    }
+    
+    observerRightPanel.innerHTML = `
+        <h3>👥 Lobby</h3>
+        ${statusMsg ? `<div class="obs-lobby-status">${statusMsg}</div>` : ''}
+        ${playersHtml}
+        ${adminControlsHtml}
+    `;
+}
+
+// --- Observer admin actions (call server then immediately refetch) ---
+
+async function obsAdmitPlayer(uid) {
+    if (!isAdmin() || !adminToken) return;
+    const baseUrl = getServerUrl();
+    if (!baseUrl) return;
+    try {
+        const httpUrl = baseUrl.replace(/^ws/, "http").replace(/\/ws\/?$/, "");
+        await fetch(`${httpUrl}/lobby/add_to_slot?uid=${uid}&admin_token=${adminToken}`, { method: 'POST' });
+        fetchObserverData();
+    } catch (e) {
+        console.error('Error admitting player:', e);
+    }
+}
+
+async function obsKickPlayer(uid) {
+    if (!isAdmin() || !adminToken) return;
+    const baseUrl = getServerUrl();
+    if (!baseUrl) return;
+    try {
+        const httpUrl = baseUrl.replace(/^ws/, "http").replace(/\/ws\/?$/, "");
+        await fetch(`${httpUrl}/lobby/kick?uid=${uid}&admin_token=${adminToken}`, { method: 'POST' });
+        fetchObserverData();
+    } catch (e) {
+        console.error('Error kicking player:', e);
+    }
+}
+
+async function obsStartTournament() {
+    if (!isAdmin() || !adminToken) return;
+    const baseUrl = getServerUrl();
+    if (!baseUrl) return;
+    try {
+        const httpUrl = baseUrl.replace(/^ws/, "http").replace(/\/ws\/?$/, "");
+        await fetch(`${httpUrl}/start_tournament?admin_token=${adminToken}`, { method: 'POST' });
+        fetchObserverData();
+    } catch (e) {
+        console.error('Error starting tournament:', e);
+    }
+}
+
+async function obsPauseTournament() {
+    if (!isAdmin() || !adminToken) return;
+    const baseUrl = getServerUrl();
+    if (!baseUrl) return;
+    try {
+        const httpUrl = baseUrl.replace(/^ws/, "http").replace(/\/ws\/?$/, "");
+        await fetch(`${httpUrl}/pause_tournament?admin_token=${adminToken}`, { method: 'POST' });
+        fetchObserverData();
+    } catch (e) {
+        console.error('Error pausing tournament:', e);
+    }
+}
+
+async function obsResumeTournament() {
+    if (!isAdmin() || !adminToken) return;
+    const baseUrl = getServerUrl();
+    if (!baseUrl) return;
+    try {
+        const httpUrl = baseUrl.replace(/^ws/, "http").replace(/\/ws\/?$/, "");
+        await fetch(`${httpUrl}/resume_tournament?admin_token=${adminToken}`, { method: 'POST' });
+        fetchObserverData();
+    } catch (e) {
+        console.error('Error resuming tournament:', e);
+    }
+}
+
+async function obsCancelTournament() {
+    if (!isAdmin() || !adminToken) return;
+    const baseUrl = getServerUrl();
+    if (!baseUrl) return;
+    try {
+        const httpUrl = baseUrl.replace(/^ws/, "http").replace(/\/ws\/?$/, "");
+        await fetch(`${httpUrl}/cancel_tournament?admin_token=${adminToken}`, { method: 'POST' });
+        fetchObserverData();
+    } catch (e) {
+        console.error('Error cancelling tournament:', e);
+    }
+}
+
+// --- Observer polling for lobby and competition data ---
+
+function startObserverPolling() {
+    stopObserverPolling();
+    observerPollGeneration++;
+    fetchObserverData();
+    observerPollInterval = setInterval(fetchObserverData, 3000);
+}
+
+function stopObserverPolling() {
+    if (observerPollInterval) {
+        clearInterval(observerPollInterval);
+        observerPollInterval = null;
+    }
+    observerPollGeneration++;
+}
+
+async function fetchObserverData() {
+    if (!isObserver) return;
+    
+    const generation = observerPollGeneration;
+    const baseUrl = getServerUrl();
+    if (!baseUrl) return;
+    
+    const httpUrl = baseUrl.replace(/^ws/, "http").replace(/\/ws\/?$/, "");
+    
+    try {
+        const [lobbyResp, compResp] = await Promise.all([
+            fetch(httpUrl + "/lobby"),
+            fetch(httpUrl + "/competition")
+        ]);
+        
+        // Discard response if we're no longer observing or generation changed
+        if (!isObserver || generation !== observerPollGeneration) return;
+        
+        if (lobbyResp.ok) {
+            const lobbyData = await lobbyResp.json();
+            window.lastLobbyData = lobbyData;
+            lobbyPlayers = lobbyData.players || [];
+            lobbySlotAssignments = lobbyData.slot_assignments || [];
+        }
+        
+        if (compResp.ok) {
+            const compData = await compResp.json();
+            window.lastCompetitionData = compData;
+            if (compData.points_to_win) {
+                serverSettings.pointsToWin = compData.points_to_win;
+            }
+            if (compData.round) currentRound = compData.round;
+            if (compData.total_rounds) totalRounds = compData.total_rounds;
+        }
+        
+        // Check again after awaits
+        if (!isObserver || generation !== observerPollGeneration) return;
+        
+        updateObserverLobbyPanel();
+    } catch (e) {
+        // Silently ignore polling errors (server may be temporarily unavailable)
+    }
 }

--- a/game.js
+++ b/game.js
@@ -1021,7 +1021,17 @@ function handleMessage(data) {
             if (gameState && gameState.running) {
                 setStatus(`Game in progress: ${p1Name} vs ${p2Name}`, "playing");
             } else {
-                setStatus(`Waiting for match to begin...`, "waiting");
+                // Check if the match is complete (a player reached pointsToWin)
+                const ptw = serverSettings.pointsToWin || 5;
+                const p1W = wins[1] || wins["1"] || 0;
+                const p2W = wins[2] || wins["2"] || 0;
+                if (p1W >= ptw) {
+                    setStatus(`${p1Name} wins the match! Waiting for next round to begin.`, "victory");
+                } else if (p2W >= ptw) {
+                    setStatus(`${p2Name} wins the match! Waiting for next round to begin.`, "victory");
+                } else {
+                    setStatus(`Waiting for match to begin...`, "waiting");
+                }
             }
             updateCanvas();
             updateScores();
@@ -1052,8 +1062,12 @@ function handleMessage(data) {
             // If we were following a winner and this is a new round, find their room
             if (observerFollowingPlayer && observerMatchComplete) {
                 if (activeRooms.length === 0) {
-                    // No rooms yet — tournament is paused between rounds
-                    setStatus(`Match complete: ${observerFollowingPlayer} advances! Waiting for next round to be started`, "victory");
+                    // No rooms yet — check if tournament is over or just paused between rounds
+                    if (currentRound >= totalRounds) {
+                        setStatus(`🏆 Tournament complete! Champion: ${observerFollowingPlayer}!`, "victory");
+                    } else {
+                        setStatus(`Match complete: ${observerFollowingPlayer} advances! Waiting for next round to be started`, "victory");
+                    }
                 } else {
                 const winnerRoom = activeRooms.find(r => 
                     r.names && (r.names[1] === observerFollowingPlayer || r.names[2] === observerFollowingPlayer)
@@ -1086,8 +1100,15 @@ function handleMessage(data) {
                 }
                 }
             } else {
-                currentRoomIndex = activeRooms.findIndex(r => r.room_id === data.current_room);
-                if (currentRoomIndex < 0) currentRoomIndex = 0;
+                // Only update room index if our current room is no longer in the list
+                const stillValid = activeRooms.some(r => r.room_id === roomId);
+                if (!stillValid) {
+                    currentRoomIndex = activeRooms.findIndex(r => r.room_id === data.current_room);
+                    if (currentRoomIndex < 0) currentRoomIndex = 0;
+                    if (activeRooms.length > 0) {
+                        roomId = activeRooms[currentRoomIndex].room_id;
+                    }
+                }
             }
             updateObserverInfo();
             updateMatchInfo();
@@ -1244,12 +1265,23 @@ function handleMessage(data) {
             competitionState = data.state;
             currentRound = data.round || 0;
             totalRounds = data.total_rounds || 1;
+            // New tournament or round — reset follow state
+            observerFollowingPlayer = null;
+            observerMatchComplete = false;
             if (data.pairings) {
                 activeRooms = data.pairings.map(p => ({
                     room_id: p.arena,
                     names: { 1: p.player1.name, 2: p.player2.name },
                     wins: { 1: 0, 2: 0 }
                 }));
+                // Select a random active game to watch
+                if (isObserver && activeRooms.length > 0) {
+                    currentRoomIndex = Math.floor(Math.random() * activeRooms.length);
+                    roomId = activeRooms[currentRoomIndex].room_id;
+                    if (ws && ws.readyState === WebSocket.OPEN) {
+                        ws.send(JSON.stringify({ action: "switch_room", room_id: roomId }));
+                    }
+                }
             }
             updateMatchInfo();
             updateObserverInfo();
@@ -1862,17 +1894,19 @@ function updateObserverInfo() {
         ${matchesTableHtml}
         <div class="observer-controls">
             <div class="key-row"><span class="key clickable-control" onclick="observerPrevMatch()">↑</span> <span class="key clickable-control" onclick="observerNextMatch()">↓</span> Next / Previous Match</div>
-            <div class="key-row clickable-control" onclick="returnToEntryScreen()"><span class="key">Esc</span> or <span class="key">\`</span> Return to lobby</div>
+            <div class="key-row clickable-control" onclick="returnToEntryScreen()"><span class="key">Esc</span> or <span class="key">\`</span> Return to Entry Screen</div>
         </div>
     `;
 }
 
 function observerPrevMatch() {
     if (!isObserver || activeRooms.length <= 1) return;
-    observerFollowingPlayer = null;
-    observerMatchComplete = false;
     currentRoomIndex = (currentRoomIndex - 1 + activeRooms.length) % activeRooms.length;
     const newRoom = activeRooms[currentRoomIndex];
+    roomId = newRoom.room_id;
+    // Manual navigation disables auto-follow
+    observerFollowingPlayer = null;
+    observerMatchComplete = false;
     if (ws && ws.readyState === WebSocket.OPEN) {
         ws.send(JSON.stringify({ action: "switch_room", room_id: newRoom.room_id }));
     }
@@ -1880,10 +1914,12 @@ function observerPrevMatch() {
 
 function observerNextMatch() {
     if (!isObserver || activeRooms.length <= 1) return;
-    observerFollowingPlayer = null;
-    observerMatchComplete = false;
     currentRoomIndex = (currentRoomIndex + 1) % activeRooms.length;
     const newRoom = activeRooms[currentRoomIndex];
+    roomId = newRoom.room_id;
+    // Manual navigation disables auto-follow
+    observerFollowingPlayer = null;
+    observerMatchComplete = false;
     if (ws && ws.readyState === WebSocket.OPEN) {
         ws.send(JSON.stringify({ action: "switch_room", room_id: newRoom.room_id }));
     }
@@ -2118,7 +2154,8 @@ async function startTournament() {
         });
         
         if (!response.ok) {
-            alert('Failed to start tournament');
+            const err = await response.json().catch(() => null);
+            alert('Failed to start tournament: ' + (err?.detail || response.statusText));
         }
         // Server will handle starting the tournament
     } catch (e) {
@@ -2268,6 +2305,16 @@ function isMatchComplete(room) {
     const s1 = room.wins?.[1] || 0;
     const s2 = room.wins?.[2] || 0;
     return s1 >= ptw || s2 >= ptw;
+}
+
+function getMatchWinnerName(room) {
+    // Return the name of the winner, or null if the match isn't complete
+    const ptw = serverSettings.pointsToWin || 5;
+    const s1 = room.wins?.[1] || 0;
+    const s2 = room.wins?.[2] || 0;
+    if (s1 >= ptw) return room.names?.[1] || "Player 1";
+    if (s2 >= ptw) return room.names?.[2] || "Player 2";
+    return null;
 }
 
 function hideObserverPanels() {

--- a/index.html
+++ b/index.html
@@ -133,6 +133,7 @@
                         <div id="round-info"></div>
                         <div id="points-to-win-info"></div>
                     </div>
+                    <div id="observer-left-content" class="hidden"></div>
                     <button id="readyBtn" class="hidden">Ready</button>
                 </div>
                 <canvas id="gameCanvas"></canvas>
@@ -153,6 +154,7 @@
                         <div class="key-row"><span class="key">Esc</span> or <span class="key">`</span> Return to lobby</div>
                     </div>
                 </div>
+                <div id="observer-right-panel" class="hidden"></div>
             </div>
         </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>CopperHead Snake</title>
     <link rel="icon" type="image/svg+xml" href="favicon.svg">
-    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="style.css?v=410">
 </head>
 <body>
     <div id="container">

--- a/style.css
+++ b/style.css
@@ -820,7 +820,7 @@ input[type="range"] {
     text-align: center;
     color: #aaa;
     font-size: 0.85em;
-    margin: 0 0 8px 0;
+    margin: -4px 0 12px 0;
 }
 
 #observer-left-content .observer-points-to-win span {
@@ -841,7 +841,7 @@ input[type="range"] {
     display: flex;
     flex-direction: column;
     gap: 2px;
-    margin-top: 12px;
+    margin-top: 16px;
 }
 
 #observer-right-panel {

--- a/style.css
+++ b/style.css
@@ -813,7 +813,7 @@ input[type="range"] {
 #observer-left-content {
     display: flex;
     flex-direction: column;
-    gap: 10px;
+    gap: 4px;
 }
 
 #observer-left-content .observer-points-to-win {
@@ -828,11 +828,11 @@ input[type="range"] {
 }
 
 #observer-left-content .observer-round-heading {
-    margin: 0;
+    margin: 4px 0 0 0;
     color: #aaa;
     font-size: 0.85em;
-    border-bottom: 1px solid #333;
-    padding-bottom: 5px;
+    padding-bottom: 0;
+}
 }
 
 #observer-left-content .observer-controls {

--- a/style.css
+++ b/style.css
@@ -813,14 +813,14 @@ input[type="range"] {
 #observer-left-content {
     display: flex;
     flex-direction: column;
-    gap: 4px;
+    gap: 2px;
 }
 
 #observer-left-content .observer-points-to-win {
     text-align: center;
     color: #aaa;
     font-size: 0.85em;
-    margin: -4px 0 6px 0;
+    margin: 0 0 8px 0;
 }
 
 #observer-left-content .observer-points-to-win span {

--- a/style.css
+++ b/style.css
@@ -619,11 +619,19 @@ input[type="range"] {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 8px;
+    padding: 6px 8px;
     margin: 4px 0;
     background: #1a1a2e;
     border-radius: 4px;
     gap: 8px;
+}
+
+.lobby-player-item .player-name {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .lobby-player-assigned {
@@ -635,14 +643,21 @@ input[type="range"] {
     color: #aaa;
 }
 
+.lobby-btn-group {
+    display: flex;
+    gap: 4px;
+    flex-shrink: 0;
+}
+
 .btn-kick {
     background: #e74c3c;
     color: white;
     border: none;
     padding: 4px 8px;
-    font-size: 0.8em;
+    font-size: 0.75em;
     border-radius: 3px;
     cursor: pointer;
+    min-width: 38px;
 }
 
 .btn-kick:hover {
@@ -654,9 +669,10 @@ input[type="range"] {
     color: white;
     border: none;
     padding: 4px 8px;
-    font-size: 0.8em;
+    font-size: 0.75em;
     border-radius: 3px;
     cursor: pointer;
+    min-width: 48px;
 }
 
 .btn-add-to-slot:hover:not(:disabled) {

--- a/style.css
+++ b/style.css
@@ -820,6 +820,7 @@ input[type="range"] {
     text-align: center;
     color: #aaa;
     font-size: 0.85em;
+    margin: -4px 0 6px 0;
 }
 
 #observer-left-content .observer-points-to-win span {
@@ -840,7 +841,7 @@ input[type="range"] {
     display: flex;
     flex-direction: column;
     gap: 2px;
-    margin-top: 8px;
+    margin-top: 12px;
 }
 
 #observer-right-panel {

--- a/style.css
+++ b/style.css
@@ -808,3 +808,206 @@ input[type="range"] {
 .note a:hover {
     color: #e67e22;
 }
+
+/* Observer mode panels */
+#observer-left-content {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+#observer-left-content .observer-points-to-win {
+    text-align: center;
+    color: #aaa;
+    font-size: 0.85em;
+}
+
+#observer-left-content .observer-points-to-win span {
+    color: #f39c12;
+    font-weight: bold;
+}
+
+#observer-left-content .observer-round-heading {
+    margin: 0;
+    color: #aaa;
+    font-size: 0.85em;
+    border-bottom: 1px solid #333;
+    padding-bottom: 5px;
+}
+
+#observer-left-content .observer-controls {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    margin-top: 5px;
+}
+
+#observer-right-panel {
+    background: #0f0f23;
+    border: 2px solid #333;
+    border-radius: 5px;
+    padding: 15px;
+    min-width: 200px;
+    max-width: 280px;
+    text-align: left;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+#observer-right-panel h3 {
+    margin: 0;
+    color: #f39c12;
+    text-align: center;
+}
+
+#observer-right-panel .obs-lobby-list {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+#observer-right-panel .obs-lobby-player {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 6px 8px;
+    background: #1a1a2e;
+    border-radius: 4px;
+    gap: 8px;
+}
+
+#observer-right-panel .obs-lobby-player .player-name {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+#observer-right-panel .obs-lobby-assigned {
+    color: #27ae60;
+    font-weight: bold;
+}
+
+#observer-right-panel .obs-lobby-waiting {
+    color: #aaa;
+}
+
+#observer-right-panel .obs-btn-group {
+    display: flex;
+    gap: 4px;
+    flex-shrink: 0;
+}
+
+#observer-right-panel .obs-btn-admit {
+    background: #27ae60;
+    color: white;
+    border: none;
+    padding: 4px 8px;
+    font-size: 0.75em;
+    border-radius: 3px;
+    cursor: pointer;
+    min-width: 48px;
+}
+
+#observer-right-panel .obs-btn-admit:hover:not(:disabled) {
+    background: #1e8449;
+}
+
+#observer-right-panel .obs-btn-admit:disabled {
+    background: #555;
+    cursor: not-allowed;
+    opacity: 0.5;
+}
+
+#observer-right-panel .obs-btn-kick {
+    background: #e74c3c;
+    color: white;
+    border: none;
+    padding: 4px 8px;
+    font-size: 0.75em;
+    border-radius: 3px;
+    cursor: pointer;
+    min-width: 38px;
+}
+
+#observer-right-panel .obs-btn-kick:hover {
+    background: #c0392b;
+}
+
+#observer-right-panel .obs-admin-controls {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    align-items: stretch;
+    margin-top: 5px;
+    border-top: 1px solid #333;
+    padding-top: 10px;
+}
+
+#observer-right-panel .obs-admin-controls button {
+    padding: 8px 12px;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.9em;
+    color: white;
+}
+
+#observer-right-panel .obs-btn-start {
+    background: #27ae60;
+}
+
+#observer-right-panel .obs-btn-start:hover:not(:disabled) {
+    background: #1e8449;
+}
+
+#observer-right-panel .obs-btn-start:disabled {
+    background: #555;
+    cursor: not-allowed;
+}
+
+#observer-right-panel .obs-btn-pause {
+    background: #e67e22;
+}
+
+#observer-right-panel .obs-btn-pause:hover {
+    background: #d35400;
+}
+
+#observer-right-panel .obs-pause-controls {
+    display: flex;
+    gap: 8px;
+}
+
+#observer-right-panel .obs-btn-resume {
+    background: #27ae60;
+    flex: 1;
+}
+
+#observer-right-panel .obs-btn-resume:hover {
+    background: #219a52;
+}
+
+#observer-right-panel .obs-btn-cancel {
+    background: #e74c3c;
+    flex: 1;
+}
+
+#observer-right-panel .obs-btn-cancel:hover {
+    background: #c0392b;
+}
+
+#observer-right-panel .obs-lobby-status {
+    font-size: 0.8em;
+    color: #aaa;
+    text-align: center;
+}
+
+#observer-right-panel .obs-no-players {
+    font-size: 0.85em;
+    color: #666;
+    text-align: center;
+    padding: 10px;
+}

--- a/style.css
+++ b/style.css
@@ -820,7 +820,7 @@ input[type="range"] {
     text-align: center;
     color: #aaa;
     font-size: 0.85em;
-    margin: -4px 0 12px 0;
+    margin: -8px 0 12px 0;
 }
 
 #observer-left-content .observer-points-to-win span {
@@ -835,13 +835,12 @@ input[type="range"] {
     border-bottom: 1px solid #333;
     padding-bottom: 5px;
 }
-}
 
 #observer-left-content .observer-controls {
     display: flex;
     flex-direction: column;
     gap: 2px;
-    margin-top: 16px;
+    margin-top: 24px;
 }
 
 #observer-right-panel {

--- a/style.css
+++ b/style.css
@@ -831,7 +831,8 @@ input[type="range"] {
     margin: 4px 0 0 0;
     color: #aaa;
     font-size: 0.85em;
-    padding-bottom: 0;
+    border-bottom: 1px solid #333;
+    padding-bottom: 5px;
 }
 }
 
@@ -839,7 +840,7 @@ input[type="range"] {
     display: flex;
     flex-direction: column;
     gap: 2px;
-    margin-top: 5px;
+    margin-top: 8px;
 }
 
 #observer-right-panel {

--- a/style.css
+++ b/style.css
@@ -11,7 +11,8 @@ body {
     min-height: 100vh;
     display: flex;
     justify-content: center;
-    align-items: center;
+    align-items: flex-start;
+    padding-top: 30px;
 }
 
 #container {
@@ -144,8 +145,6 @@ h1 {
 
 #competition-matches {
     margin-bottom: 15px;
-    max-height: 150px;
-    overflow-y: auto;
 }
 
 #competition-matches .matches-table {
@@ -259,7 +258,6 @@ button:disabled {
 
 #status.victory {
     color: #f1c40f;  /* Gold - celebration */
-    font-weight: bold;
 }
 
 #status.error {
@@ -609,6 +607,7 @@ input[type="range"] {
     text-align: center;
     font-weight: bold;
     color: #f39c12;
+    white-space: nowrap;
 }
 
 /* Lobby panel styles */


### PR DESCRIPTION
## Summary
- upgrade Observe mode with a lobby panel, admin controls, and match auto-cycling
- polish the observer and entry screen layout and spacing
- switch admins directly into Observe mode after a successful start-tournament request
- update the client docs/changelog to match the new admin tournament flow

## Testing
- Not run (no automated client test suite in this repo)
